### PR TITLE
Feat: Add CDN for css/js for materialize across html files

### DIFF
--- a/assetlist.html
+++ b/assetlist.html
@@ -1,70 +1,88 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    />
     <title>Document</title>
-</head>
-<body>
+  </head>
+  <body>
     <h3>Elijah</h3>
-    <img src="assets/images/Pod-Elijah.jpg" alt="Image of Elijah">
+    <img src="assets/images/Pod-Elijah.jpg" alt="Image of Elijah" />
     <audio controls>
-        <source src="assets/podcasts/Pod-Elijah.mp3">
+      <source src="assets/podcasts/Pod-Elijah.mp3" />
     </audio>
     <p>
-        Elijah, in their 40s, shares their journey of discovering their non-binary, trans-masculine identity while navigating their Jewish faith.
-        Despite initial concerns about the compatibility of being trans and Jewish, Elijah found a supportive community that 
-        allowed them to embrace both aspects of their identity. They highlight the significance of a transformative visit to the 
-        Western Wall and the challenges faced from negative online reactions. Elijah emphasizes the importance of personal faith 
-        and hopes for a broader understanding of the multi-faceted nature of being transgender.
+      Elijah, in their 40s, shares their journey of discovering their
+      non-binary, trans-masculine identity while navigating their Jewish faith.
+      Despite initial concerns about the compatibility of being trans and
+      Jewish, Elijah found a supportive community that allowed them to embrace
+      both aspects of their identity. They highlight the significance of a
+      transformative visit to the Western Wall and the challenges faced from
+      negative online reactions. Elijah emphasizes the importance of personal
+      faith and hopes for a broader understanding of the multi-faceted nature of
+      being transgender.
     </p>
-    <hr>
+    <hr />
     <h3>Emily</h3>
-    <img src="assets/images/Pod-Emily.jpg" alt="Image of Emily">
+    <img src="assets/images/Pod-Emily.jpg" alt="Image of Emily" />
     <audio controls>
-        <source src="assets/podcasts/Pod-Emily.mp3" type="audio/mp3">
+      <source src="assets/podcasts/Pod-Emily.mp3" type="audio/mp3" />
     </audio>
     <p>
-        Emily, age 16, reflects on her journey as a lesbian and her feelings for her best friend. She grapples with societal stereotypes
-        and fears about coming out to her family and friends. Emily emphasizes the importance of acceptance, understanding, and
-        the need to see beyond stereotypes in order to embrace love in all its forms.
+      Emily, age 16, reflects on her journey as a lesbian and her feelings for
+      her best friend. She grapples with societal stereotypes and fears about
+      coming out to her family and friends. Emily emphasizes the importance of
+      acceptance, understanding, and the need to see beyond stereotypes in order
+      to embrace love in all its forms.
     </p>
-    <hr>
+    <hr />
     <h3>Mark</h3>
-    <img src="assets/images/Pod-Mark.jpg" alt="Image of Mark">
+    <img src="assets/images/Pod-Mark.jpg" alt="Image of Mark" />
     <audio controls>
-        <source src="assets/podcasts/Pod-Mark.mp3" type="audio/mp3">
+      <source src="assets/podcasts/Pod-Mark.mp3" type="audio/mp3" />
     </audio>
     <p>
-       Mark, a 20-year-old homosexual man from Brussels, reflects on his experiences of being mocked and feeling unsafe due to 
-       his sexual orientation. However, after being attacked, he found strength and resilience. With the support of friends and
-       LGBTQ+ communities, he became an advocate for acceptance and equality. His story serves as an inspiration to others,
-       emphasizing the importance of embracing one's true self and standing up against prejudice.
+      Mark, a 20-year-old homosexual man from Brussels, reflects on his
+      experiences of being mocked and feeling unsafe due to his sexual
+      orientation. However, after being attacked, he found strength and
+      resilience. With the support of friends and LGBTQ+ communities, he became
+      an advocate for acceptance and equality. His story serves as an
+      inspiration to others, emphasizing the importance of embracing one's true
+      self and standing up against prejudice.
     </p>
-    <hr>
+    <hr />
     <h3>Nikki</h3>
-    <img src="assets/images/Pod-Nikki.jpg" alt="Image of Nikki">
+    <img src="assets/images/Pod-Nikki.jpg" alt="Image of Nikki" />
     <audio controls>
-        <source src="assets/podcasts/Pod-Nikki.mp3" type="audio/mp3">
+      <source src="assets/podcasts/Pod-Nikki.mp3" type="audio/mp3" />
     </audio>
     <p>
-        Nikki, a 26-year-old from London, shares their journey of discovering and accepting their transgender identity. 
-        From early memories of feeling different to finding understanding on YouTube, Nikki transitioned without explicitly 
-        telling their family. They emphasize that being trans is just a part of who they are and desire happiness, respect, 
-        and acceptance. Their story challenges prejudices and highlights the shared humanity between trans and cisgender 
-        individuals.
+      Nikki, a 26-year-old from London, shares their journey of discovering and
+      accepting their transgender identity. From early memories of feeling
+      different to finding understanding on YouTube, Nikki transitioned without
+      explicitly telling their family. They emphasize that being trans is just a
+      part of who they are and desire happiness, respect, and acceptance. Their
+      story challenges prejudices and highlights the shared humanity between
+      trans and cisgender individuals.
     </p>
-    <hr>
+    <hr />
     <h3>Pedro</h3>
-    <img src="assets/images/Pod-Pedro.jpg" alt="Image of Pedro">
+    <img src="assets/images/Pod-Pedro.jpg" alt="Image of Pedro" />
     <audio controls>
-        <source src="assets/podcasts/Pod-Pedro.mp3" type="audio/mp3">
+      <source src="assets/podcasts/Pod-Pedro.mp3" type="audio/mp3" />
     </audio>
     <p>
-        Pedro, a 27-year-old man from a small, conservative village in Spain, shares his journey of coming to terms with his 
-        sexuality. After facing rejection from his family, he found support in Barcelona's LGBTQ+ community. Through resilience 
-        and self-acceptance, he discovered love and happiness. Although his family hasn't fully accepted him, he remains hopeful
-        and advocates for acceptance and equality.
+      Pedro, a 27-year-old man from a small, conservative village in Spain,
+      shares his journey of coming to terms with his sexuality. After facing
+      rejection from his family, he found support in Barcelona's LGBTQ+
+      community. Through resilience and self-acceptance, he discovered love and
+      happiness. Although his family hasn't fully accepted him, he remains
+      hopeful and advocates for acceptance and equality.
     </p>
-</body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  </body>
 </html>

--- a/discussion.html
+++ b/discussion.html
@@ -1,23 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="assets/css/style.css">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    />
     <title>Us</title>
-</head>
+  </head>
 
-<body>
-    <div><image></image>
-
-    </div>
+  <body>
+    <div><image></image></div>
     <h2 id="empatheticQuestion"></h2>
-    <button>
-        Start a discussion
-    </button>
-    <div><image></image>
-
-    </div>
-</body>
+    <button>Start a discussion</button>
+    <div><image></image></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    />
     <title>Document</title>
   </head>
   <body>
     <script src="./assets/js/script.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
   </body>
 </html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,12 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    />
     <title>Testimonials</title>
-</head>
-<body>
+  </head>
+  <body>
     <h2>Listen to their Stories</h2>
-    <iframe src="assetlist.html" title="Testimonial podcasts" frameborder="0" width="100%" height="700px"></iframe>
-</body>
+    <iframe
+      src="assetlist.html"
+      title="Testimonial podcasts"
+      frameborder="0"
+      width="100%"
+      height="700px"
+    ></iframe>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
- Accessed the [Materialize](https://materializecss.com/getting-started.html) documentation and inserted the CDN (the "link") for Materialize CSS and Materialize JS across all html documents.